### PR TITLE
Improve setup documentation for Google Sheets and environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,12 @@ OPENAI_API_KEY=your_openai_api_key_here
 # https://cloud.google.com/iam/docs/creating-managing-service-account-keys
 # Used by: download-sheets
 GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/service_account.json
+
+# -----------------------------------------------------------------------------
+# Neo4j (local Docker instance)
+# -----------------------------------------------------------------------------
+# Used by: various targets that interact with Neo4j graph database
+# Default Docker setup uses bolt://localhost:7687
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=your_neo4j_password_here

--- a/README.md
+++ b/README.md
@@ -216,8 +216,10 @@ cp /path/to/downloaded-key.json ~/.config/gspread/service_account.json
 ```
 
 **Verify setup:**
+
+Use a spreadsheet ID for a Google Sheet that has been shared with your service account (replace `<YOUR_SPREADSHEET_ID>` below):
 ```bash
-uv run download-sheets --spreadsheet "1h-kOdyvVb1EJPqgTiklTN9Z8br_8bP8KGmxA19clo7Q" --output-dir /tmp/test
+uv run download-sheets --spreadsheet "<YOUR_SPREADSHEET_ID>" --output-dir /tmp/test
 ```
 
 ### Run the Data Pipeline


### PR DESCRIPTION
## Summary
- Add reference to `.env.example` in Environment Setup section
- Add comprehensive **Google Sheets Authentication** section with step-by-step instructions for service account setup
- Document the critical requirement to share spreadsheets with the service account email
- Add missing environment variables (`NCBI_API_KEY`, `OPENAI_API_KEY`) to README
- Document alternative gspread credential location (`~/.config/gspread/`)
- Add verification command for testing Google Sheets setup

## Problem Addressed
The README.md had gaps that would make it difficult for a new contributor to run all justfile targets, particularly:
1. Google Sheets authentication setup was only partially documented (path mentioned but not how to create service account or share sheets)
2. `.env.example` file existed but wasn't referenced
3. Some environment variables in `.env.example` were missing from README

Fixes #153

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm the Google Sheets verification command works with valid credentials
- [ ] Check that all environment variables in `.env.example` are now documented in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)